### PR TITLE
feat: add toggle for epic loading prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ https://github.com/xiaoruange39/astrbot_plugin_epic_freegame
 | `cron_time` | string | 定时推送 Cron 表达式，为空则不启用 | 空 |
 | `enable_cache` | bool | 启用缓存对比，避免重复推送 | `true` |
 | `dark_mode` | bool | 深色模式开关 | `true` |
+| `show_loading_message` | bool | 手动 `/epic` 时是否显示“正在获取”提示 | `true` |
 | `push_targets` | list | 白名单群组 UMO 列表 | `[]` |
 
 ### 🕐 Cron 表达式示例

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -24,6 +24,12 @@
         "hint": "开启深色模式，关闭则为浅色模式",
         "default": true
     },
+    "show_loading_message": {
+        "description": "显示“正在获取”提示消息",
+        "type": "bool",
+        "hint": "开启后，手动执行 /epic 时会先发送“正在获取 Epic 免费游戏信息，请稍候...”提示。",
+        "default": true
+    },
     "push_targets": {
         "description": "白名单群组UMO列表",
         "type": "list",

--- a/main.py
+++ b/main.py
@@ -243,6 +243,7 @@ class EpicFreeGamePlugin(Star):
         self.cron_time: str = config.get("cron_time", "")
         self.enable_cache: bool = config.get("enable_cache", True)
         self.dark_mode: bool = config.get("dark_mode", True)
+        self.show_loading_message: bool = config.get("show_loading_message", True)
 
         # 从配置中读取推送目标列表
         push_targets_raw = config.get("push_targets", [])
@@ -289,7 +290,8 @@ class EpicFreeGamePlugin(Star):
     @filter.command("epic")
     async def cmd_epic(self, event: AstrMessageEvent):
         '''查询当前 Epic 免费游戏'''
-        yield event.plain_result("正在获取 Epic 免费游戏信息，请稍候... 🎮")
+        if self.show_loading_message:
+            yield event.plain_result("正在获取 Epic 免费游戏信息，请稍候... 🎮")
 
         try:
             games = await self._fetch_games()


### PR DESCRIPTION
/epic 指令里的“正在获取 Epic 免费游戏信息，请稍候... 🎮”改为可配置开关：新增 show_loading_message 配置项，并在命令处理时按该开关决定是否发送该提示消息（默认开启）。